### PR TITLE
build: Add support for Droidian translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build/
 /subprojects/*
 !/subprojects/*.wrap
 .flatpak-builder/
+droidian_po/*.mo

--- a/build-aux/msg_droidian.sh
+++ b/build-aux/msg_droidian.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+FILES="panels/usb panels/power panels/nfc panels/fingerprint panels/waydroid"
+
+usage() {
+	echo "usage: build-aux/msg_droidian.sh language"
+	exit 0
+}
+
+(( $# != 1 )) && usage
+
+pushd . >/dev/null
+
+cd "$(git rev-parse --show-toplevel)"
+
+lang=po/$1.po
+filename=$(basename $lang)
+
+trap "rm -f /tmp/gcc$$.pot" EXIT
+
+>/tmp/gcc$$.pot
+
+git ls-files panels/usb panels/power panels/nfc panels/fingerprint  | grep -E '(.*\.[ch]$|.*\.ui$)' | while read file
+do
+	xgettext --from-code=UTF-8 -j $file -o /tmp/gcc$$.pot
+done
+
+mkdir -p droidian_po
+if [ -e droidian_po/$filename ]
+then
+	msgcat --use-first $lang droidian_po/$filename > droidian_po/new_$filename
+else
+	cat $lang > droidian_po/new_$filename
+fi
+msgmerge -N droidian_po/new_$filename /tmp/gcc$$.pot > droidian_po/$filename
+
+rm -f droidian_po/new_$filename
+
+popd >/dev/null

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,12 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_CPPFLAGS_MAINT_APPEND = -DSSHD_SERVICE=\"ssh.service\"
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1 -Wl,-z,defs
 
+TRANSLATIONS := $(notdir $(shell find droidian_po -name '*.po'))
+define TRANSLATION_install
+	msgcat --use-first po/$(1) droidian_po/$(1) >po/$(1).new
+	mv po/$(1).new po/$(1)
+endef
+
 # Not in Ubuntu main yet https://launchpad.net/bugs/1892456
 ifeq ($(shell dpkg-vendor --is Ubuntu && echo yes),yes)
 DISTRIBUTOR_LOGO := /usr/share/pixmaps/ubuntu-logo-text.png
@@ -23,6 +29,8 @@ endif
 	dh $@
 
 override_dh_auto_configure:
+	$(info Droidian translations: $(TRANSLATIONS))
+	$(foreach translation,$(TRANSLATIONS),$(call TRANSLATION_install,$(translation)))
 	dh_auto_configure -- \
 		-Dprivileged_group=sudo \
 		-Ddocumentation=true \


### PR DESCRIPTION
 Add a script allowing translators to work on Droidian panels.
    
Ex:
`build-aux/msg_droidian.sh fr`
    
This will generate a fr.po file in droidian_po directory. Build system will merge GNOME translations with Droidian translations.