### PR TITLE
display: Add swipe to wake settings

### DIFF
--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -105,6 +105,10 @@ struct _CcDisplayPanel
   AdwComboRow    *primary_display_row;
   AdwPreferencesGroup *single_display_settings_group;
   AdwSwitchRow      *double_tap_row;
+  AdwSwitchRow      *swipe_up_row;
+  AdwSwitchRow      *swipe_down_row;
+  AdwSwitchRow      *swipe_left_row;
+  AdwSwitchRow      *swipe_right_row;
 
   GtkShortcutController *toplevel_shortcuts;
   GtkShortcut *escape_shortcut;
@@ -623,6 +627,10 @@ cc_display_panel_class_init (CcDisplayPanelClass *klass)
   gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, night_light_row);
   gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, primary_display_row);
   gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, double_tap_row);
+  gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, swipe_up_row);
+  gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, swipe_down_row);
+  gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, swipe_left_row);
+  gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, swipe_right_row);
   gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, single_display_settings_group);
   gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, toplevel_shortcuts);
 
@@ -1176,6 +1184,34 @@ cc_display_panel_init (CcDisplayPanel *self)
                            G_SETTINGS_BIND_DEFAULT);
 
 
+        }
+      if (g_settings_get_boolean (self->droidian_settings, "touchpanel-swipe-up-available"))
+        {
+          gtk_widget_show (GTK_WIDGET (self->swipe_up_row));
+          g_settings_bind (self->droidian_settings, "touchpanel-swipe-up",
+                           self->swipe_up_row, "active",
+                           G_SETTINGS_BIND_DEFAULT);
+        }
+      if (g_settings_get_boolean (self->droidian_settings, "touchpanel-swipe-down-available"))
+        {
+          gtk_widget_show (GTK_WIDGET (self->swipe_down_row));
+          g_settings_bind (self->droidian_settings, "touchpanel-swipe-down",
+                           self->swipe_down_row, "active",
+                           G_SETTINGS_BIND_DEFAULT);
+        }
+      if (g_settings_get_boolean (self->droidian_settings, "touchpanel-swipe-left-available"))
+        {
+          gtk_widget_show (GTK_WIDGET (self->swipe_left_row));
+          g_settings_bind (self->droidian_settings, "touchpanel-swipe-left",
+                           self->swipe_left_row, "active",
+                           G_SETTINGS_BIND_DEFAULT);
+        }
+      if (g_settings_get_boolean (self->droidian_settings, "touchpanel-swipe-right-available"))
+        {
+          gtk_widget_show (GTK_WIDGET (self->swipe_right_row));
+          g_settings_bind (self->droidian_settings, "touchpanel-swipe-right",
+                           self->swipe_right_row, "active",
+                           G_SETTINGS_BIND_DEFAULT);
         }
     }
 }

--- a/panels/display/cc-display-panel.ui
+++ b/panels/display/cc-display-panel.ui
@@ -146,6 +146,38 @@
                             <property name="use_underline">True</property>
                           </object>
                         </child>
+                        <child>
+                          <object class="AdwSwitchRow" id="swipe_up_row">
+                            <property name="visible">False</property>
+                            <property name="title" translatable="yes">Swipe up to wake up</property>
+                            <property name="subtitle" translatable="yes">Wake up the screen by swiping up</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="AdwSwitchRow" id="swipe_down_row">
+                            <property name="visible">False</property>
+                            <property name="title" translatable="yes">Swipe down to wake up</property>
+                            <property name="subtitle" translatable="yes">Wake up the screen by swiping down</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="AdwSwitchRow" id="swipe_left_row">
+                            <property name="visible">False</property>
+                            <property name="title" translatable="yes">Swipe left to wake up</property>
+                            <property name="subtitle" translatable="yes">Wake up the screen by swiping left</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="AdwSwitchRow" id="swipe_right_row">
+                            <property name="visible">False</property>
+                            <property name="title" translatable="yes">Swipe right to wake up</property>
+                            <property name="subtitle" translatable="yes">Wake up the screen by swiping right</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                        </child>
                       </object>
 
                     </child>


### PR DESCRIPTION
Added swipe to wake settings to the display menu.
For example OnePlus 3 and 5 have these swipe to wake gestures.
Related to [mobile-settings/pull/3](https://github.com/droidian/mobile-settings/pull/3)